### PR TITLE
Reverting the boot mode combo button lock.

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -2088,8 +2088,7 @@ static void APP_ProcessKey(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld)
 		gUpdateStatus   = true;
 	}
 
-//	if (gF_LOCK && (Key == KEY_PTT || Key == KEY_SIDE2 || Key == KEY_SIDE1))
-	if (gF_LOCK && Key == KEY_PTT)
+	if (gF_LOCK && (Key == KEY_PTT || Key == KEY_SIDE2 || Key == KEY_SIDE1))
 		return;
 
 	if (!bFlag)


### PR DESCRIPTION
Without this the boot mode selection process is uncontrollable. It immediately exits the menu and activates ptt or sidebutton functions.