### PR TITLE
Prevent the scan results screen from jumping back to the main page

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1730,6 +1730,9 @@ void APP_TimeSlice500ms(void)
 								GUI_SelectNextDisplay(DISPLAY_FM);
 							else
 						#endif
+						#ifndef ENABLE_NO_SCAN_TIMEOUT
+							if (gScreenToDisplay != DISPLAY_SCANNER)
+						#endif
 								GUI_SelectNextDisplay(DISPLAY_MAIN);
 					}
 				}

--- a/app/app.c
+++ b/app/app.c
@@ -1730,7 +1730,7 @@ void APP_TimeSlice500ms(void)
 								GUI_SelectNextDisplay(DISPLAY_FM);
 							else
 						#endif
-						#ifndef ENABLE_NO_SCAN_TIMEOUT
+						#ifdef ENABLE_NO_SCAN_TIMEOUT
 							if (gScreenToDisplay != DISPLAY_SCANNER)
 						#endif
 								GUI_SelectNextDisplay(DISPLAY_MAIN);


### PR DESCRIPTION
if u ENABLE_NO_SCAN_TIMEOUT
u would also want the scan result to stay on screen until exit key 