### PR TITLE
Disable saving channel settings on parameter change

### DIFF
--- a/app/action.c
+++ b/app/action.c
@@ -56,8 +56,8 @@ void ACTION_Power(void)
 	if (++gTxVfo->OUTPUT_POWER > OUTPUT_POWER_HIGH)
 		gTxVfo->OUTPUT_POWER = OUTPUT_POWER_LOW;
 
-	//gRequestSaveChannel = 1;
-	gRequestSaveChannel = 2;
+	gRequestSaveChannel = 1;
+
 
 	#ifdef ENABLE_VOICE
 		gAnotherVoiceID   = VOICE_ID_POWER;

--- a/app/menu.c
+++ b/app/menu.c
@@ -320,7 +320,7 @@ void MENU_AcceptSetting(void)
 			if (IS_FREQ_CHANNEL(gTxVfo->CHANNEL_SAVE))
 			{
 				gTxVfo->STEP_SETTING = gSubMenuSelection;
-				gRequestSaveChannel  = 2;
+				gRequestSaveChannel  = 1;
 				return;
 			}
 			gSubMenuSelection = gTxVfo->STEP_SETTING;
@@ -328,7 +328,7 @@ void MENU_AcceptSetting(void)
 
 		case MENU_TXP:
 			gTxVfo->OUTPUT_POWER = gSubMenuSelection;
-			gRequestSaveChannel = 2;
+			gRequestSaveChannel = 1;
 			return;
 
 		case MENU_T_DCS:
@@ -400,17 +400,17 @@ void MENU_AcceptSetting(void)
 
 		case MENU_W_N:
 			gTxVfo->CHANNEL_BANDWIDTH = gSubMenuSelection;
-			gRequestSaveChannel       = 2;
+			gRequestSaveChannel       = 1;
 			return;
 
 		case MENU_SCR:
 			gTxVfo->SCRAMBLING_TYPE = gSubMenuSelection;
-			gRequestSaveChannel     = 2;
+			gRequestSaveChannel     = 1;
 			return;
 
 		case MENU_BCL:
 			gTxVfo->BUSY_CHANNEL_LOCK = gSubMenuSelection;
-			gRequestSaveChannel       = 2;
+			gRequestSaveChannel       = 1;
 			return;
 
 		case MENU_MEM_CH:
@@ -541,7 +541,7 @@ void MENU_AcceptSetting(void)
 		#ifdef ENABLE_COMPANDER
 			case MENU_COMPAND:
 				gTxVfo->Compander = gSubMenuSelection;
-				gRequestSaveChannel = 2;
+				gRequestSaveChannel = 1;
 				return;
 		#endif
 
@@ -621,7 +621,7 @@ void MENU_AcceptSetting(void)
 
 		case MENU_AM:
 			gTxVfo->AM_CHANNEL_MODE = gSubMenuSelection;
-			gRequestSaveChannel     = 2;
+			gRequestSaveChannel     = 1;
 			return;
 
 		#ifdef ENABLE_AM_FIX


### PR DESCRIPTION
In your implementation changing some channel settings triggers saving to eeprom, but this is not the case for DCS, CTCSS and frequency shift settings. It is inconsistent.
I personally don't like the autosave function. I would like to be able to change some settings momentarily and have the backup in the memory that I can get back to simply by switching channels back and forth. This is especially the case with TX power. I have all my channels set to LOW but I want to be able to switch to HIGH for the time that I need and have it always fallback to LOW next time I use the radio. At least the long/F press of button 6 shouldn't trigger autosave either way I think, just like TX power change side button function doesn't (another inconsistency).
This is a matter of preference I guess, so feel free to reject this commit, just note the inconsistencies I mentioned.