### PR TITLE
Fix non-overlay build

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1712,7 +1712,11 @@ void APP_TimeSlice500ms(void)
 	{
 		BOARD_ADC_GetBatteryInfo(&gBatteryCurrentVoltage, &gBatteryCurrent);
 		if (gBatteryCurrent > 500 || gBatteryCalibration[3] < gBatteryCurrentVoltage)
-			overlay_FLASH_RebootToBootloader();
+			#if defined(ENABLE_OVERLAY)
+				overlay_FLASH_RebootToBootloader();
+			#else
+				NVIC_SystemReset();
+			#endif
 		return;
 	}
 


### PR DESCRIPTION
This PR has a single change which adds an if-def to app/app.c so builds with ENABLE_OVERLAY=0 don't blank-boot the radio after flash.