### PR TITLE
BUG FIX: Charging info from ENABLE_SHOW_CHARGE_LEVEL doesn't show up

### DIFF
--- a/ui/main.c
+++ b/ui/main.c
@@ -709,13 +709,10 @@ void UI_DisplayMain(void)
 		#endif
 
 		#if defined(ENABLE_AM_FIX) && defined(ENABLE_AM_FIX_SHOW_DATA)
-			if (gEeprom.VfoInfo[gEeprom.RX_CHANNEL].AM_mode && gSetting_AM_fix)
+			if (rx && gEeprom.VfoInfo[gEeprom.RX_CHANNEL].AM_mode && gSetting_AM_fix)
 			{
-				if (rx)
-				{
-					AM_fix_print_data(gEeprom.RX_CHANNEL, String);
-					UI_PrintStringSmall(String, 2, 0, 3);
-				}
+				AM_fix_print_data(gEeprom.RX_CHANNEL, String);
+				UI_PrintStringSmall(String, 2, 0, 3);
 			}
 			else
 		#endif
@@ -726,7 +723,7 @@ void UI_DisplayMain(void)
 			else
 		#endif
 
-		if (rx || gCurrentFunction == FUNCTION_FOREGROUND)
+		if (rx || gCurrentFunction == FUNCTION_FOREGROUND || gCurrentFunction == FUNCTION_POWER_SAVE)
 		{
 			#if 1
 				if (gSetting_live_DTMF_decoder && gDTMF_RX_live[0] != 0)


### PR DESCRIPTION
first part:
`gEeprom.VfoInfo[gEeprom.RX_CHANNEL].AM_mode && gSetting_AM_fix` this can be true but the line doesn't have to be used because `rx` is false

second part:
`gCurrentFunction` changes to `FUNCTION_POWER_SAVE` when powersave activates then the line disaapears