### PR TITLE
Fix intermittent issue where gain may never adjust

### DIFF
--- a/am_fix.c
+++ b/am_fix.c
@@ -447,9 +447,6 @@ const uint8_t orig_pga       = 6;   //  -3dB
 			gain_table_index[vfo] = (index <= max_index) ? index : max_index;     // limit the gain index
 		}
 
-		if (gain_table_index[vfo] == gain_table_index_prev[vfo])
-			return;     // no gain change
-
 #endif
 
 		{	// apply the new settings to the front end registers

--- a/misc.h
+++ b/misc.h
@@ -267,7 +267,7 @@ extern uint8_t               gNextMrChannel;
 extern ReceptionMode_t       gRxReceptionMode;
 
 extern uint8_t               gRestoreMrChannel;
-extern uint8_t               gCurrentScanList;
+extern scan_next_chan_t      gCurrentScanList;
 extern uint32_t              gRestoreFrequency;
 
 extern bool                  gRxVfoIsActive;


### PR DESCRIPTION
I've found in cases where AM reception can disappear and reappear if I hold the radio wrong, gain can get stuck at 0dB and never adjust until the radio is rebooted. The early return appears to be what caused it for me.

I was curious to find out if there was a race condition from running every 10ms but yielded nothing more.