### PR TITLE
Use newlib-nano as libc, saves 500 bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,7 @@ ifeq ($(ENABLE_BAND_SCOPE),1)
 endif
 
 LDFLAGS = -mcpu=cortex-m0 -nostartfiles -Wl,-T,firmware.ld
+LDFLAGS += --specs=nano.specs
 
 ifeq ($(DEBUG),1)
 	ASFLAGS += -g

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -835,7 +835,7 @@ void BK4819_SetCompander(const unsigned int mode)
 	
 	if (mode == 0)
 	{	// disable
-		BK4819_WriteRegister(BK4819_REG_31, r31 & ~(1u < 3));
+		BK4819_WriteRegister(BK4819_REG_31, r31 & ~(1u << 3));
 		return;
 	}
 


### PR DESCRIPTION
The arm-none-eabi target uses newlib by default. Adding a linker flag to use newlib-nano saves ~500 bytes on the compiled binary with no perceived change in functionality.

I've also fixed a build error I was getting with clang in bk4819.c about bitwise negation of a boolean expression. GCC doesn't warn about it so I'm assuming it's silently changing/correcting it during compilation.