### PR TITLE
-Wpadded, reorder struct fields, saves 400 bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ ifeq ($(ENABLE_LTO), 1)
 	CFLAGS += -flto=2
 endif
 
+CFLAGS += -Wpadded
 CFLAGS += -DPRINTF_INCLUDE_CONFIG_H
 CFLAGS += -DGIT_HASH=\"$(GIT_HASH)\"
 ifeq ($(ENABLE_SWD),1)

--- a/driver/adc.h
+++ b/driver/adc.h
@@ -42,8 +42,10 @@ enum ADC_CH_MASK {
 typedef enum ADC_CH_MASK ADC_CH_MASK;
 
 typedef struct {
-	uint8_t CLK_SEL;
+	uint16_t EXTTRIG_SEL;
+	uint16_t IE_CHx_EOC;
 	ADC_CH_MASK CH_SEL;
+	uint8_t CLK_SEL;
 	uint8_t AVG;
 	uint8_t CONT;
 	uint8_t MEM_MODE;
@@ -51,13 +53,12 @@ typedef struct {
 	uint8_t SMPL_SETUP;
 	uint8_t SMPL_WIN;
 	uint8_t ADC_TRIG;
-	uint16_t EXTTRIG_SEL;
-	bool CALIB_OFFSET_VALID;
-	bool CALIB_KD_VALID;
 	uint8_t DMA_EN;
-	uint16_t IE_CHx_EOC;
 	uint8_t IE_FIFO_HFULL;
 	uint8_t IE_FIFO_FULL;
+	bool CALIB_OFFSET_VALID;
+	bool CALIB_KD_VALID;
+	uint8_t _pad[1];
 } ADC_Config_t;
 
 uint8_t ADC_GetChannelNumber(ADC_CH_MASK Mask);

--- a/settings.h
+++ b/settings.h
@@ -127,7 +127,15 @@ typedef struct {
 	uint8_t               field7_0xa;
 	uint8_t               field8_0xb;
 
-	uint32_t              POWER_ON_PASSWORD;
+	#ifdef ENABLE_FMRADIO
+		uint16_t          FM_SelectedFrequency;
+		uint8_t           FM_SelectedChannel;
+		bool              FM_IsMrMode;
+		uint16_t          FM_FrequencyPlaying;
+		uint16_t          FM_LowerLimit;
+		uint16_t          FM_UpperLimit;
+	#endif
+
 	uint8_t               SQUELCH_LEVEL;
 	uint8_t               TX_TIMEOUT_TIMER;
 	bool                  KEY_LOCK;
@@ -152,24 +160,9 @@ typedef struct {
 
 	uint8_t               field29_0x26;
 	uint8_t               field30_0x27;
-
-	uint16_t              VOX1_THRESHOLD;
-	uint16_t              VOX0_THRESHOLD;
-
-	#ifdef ENABLE_FMRADIO
-		uint16_t          FM_SelectedFrequency;
-		uint8_t           FM_SelectedChannel;
-		bool              FM_IsMrMode;
-		uint16_t          FM_FrequencyPlaying;
-	#endif
 	
 	uint8_t               field37_0x32;
 	uint8_t               field38_0x33;
-
-	#ifdef ENABLE_FMRADIO
-		uint16_t          FM_LowerLimit;
-		uint16_t          FM_UpperLimit;
-	#endif
 
 	bool                  AUTO_KEYPAD_LOCK;
 	#if defined(ENABLE_ALARM) || defined(ENABLE_TX1750)
@@ -216,11 +209,16 @@ typedef struct {
 	uint8_t               VOLUME_GAIN;
 	uint8_t               DAC_GAIN;
 
+	VFO_Info_t            VfoInfo[2];
+	uint32_t              POWER_ON_PASSWORD;
+	uint16_t              VOX1_THRESHOLD;
+	uint16_t              VOX0_THRESHOLD;
+
 	uint8_t               field77_0x95;
 	uint8_t               field78_0x96;
 	uint8_t               field79_0x97;
 
-	VFO_Info_t            VfoInfo[2];
+	uint8_t _pad[1];
 } EEPROM_Config_t;
 extern EEPROM_Config_t gEeprom;
 


### PR DESCRIPTION
This PR enables the -Wpadded compiler flag which warns about alignment issues with structs. I've quickly re-ordered some struct fields and made a 400 byte saving on the compiled binary. I say 'quickly' as there could be extra savings but I don't believe it's worth extra time chasing after.

Struct ordering is important for locality so please let me know if this has any side-effects. My preliminary testing shows no impact on functionality.