### PR TITLE
Retain space saving benefits when not using LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,9 +170,14 @@ CFLAGS = -Os -Wall -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delet
 ifeq ($(ENABLE_LTO), 1)
 #	CFLAGS += -flto
 	CFLAGS += -flto=2
+else
+#	We get most of the space savings if LTO creates problems
+	CFLAGS += -ffunction-sections -fdata-sections
 endif
 
+# May cause unhelpful build failures
 #CFLAGS += -Wpadded
+
 CFLAGS += -DPRINTF_INCLUDE_CONFIG_H
 CFLAGS += -DGIT_HASH=\"$(GIT_HASH)\"
 ifeq ($(ENABLE_SWD),1)
@@ -279,6 +284,11 @@ LDFLAGS = -mcpu=cortex-m0 -nostartfiles -Wl,-T,firmware.ld
 
 # Use newlib-nano instead of newlib
 LDFLAGS += --specs=nano.specs
+
+ifeq ($(ENABLE_LTO), 0)
+#	Throw away unneeded func/data sections like LTO does
+	LDFLAGS += -Wl,--gc-sections
+endif
 
 ifeq ($(DEBUG),1)
 	ASFLAGS += -g

--- a/firmware.ld
+++ b/firmware.ld
@@ -17,7 +17,7 @@ SECTIONS
 	.text :
 	{
 		. = ALIGN(4);
-		*(.text.isr)           /* .text sections of code  */
+		KEEP(*(.text.isr)) /* .text sections of code  */
 		*(.text)           /* .text sections of code  */
 		*(.text*)          /* .text* sections of code */
 		*(.rodata)         /* .rodata sections        */


### PR DESCRIPTION
This PR changes the Makefile to use `-ffunction-sections -fdata-sections` compiler flags and `-Wl,--gc-sections` linker flag when not building with link-time optimisation, and changes the linker script to keep the vector table (.text.isr) so the linker doesn't throw it away and leave us with unbootable firmware.

Many thanks to @DualTachyon on Telegram for helping to debug this.