### PR TITLE
Save 300 bytes by using GCC builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ LD = arm-none-eabi-gcc
 
 ifeq ($(ENABLE_CLANG),0)
 	CC += arm-none-eabi-gcc
-# Use GCC's linker to avoid undefined symbol errors
+#	Use GCC's linker to avoid undefined symbol errors
 #	LD += arm-none-eabi-gcc
 else
 #	May need to adjust this to match your system
@@ -200,7 +200,7 @@ endif
 
 CFLAGS =
 ifeq ($(ENABLE_CLANG),0)
-	CFLAGS += -Os -Wall -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delete-null-pointer-checks -std=c11 -MMD
+	CFLAGS += -Os -Wall -Werror -mcpu=cortex-m0 -std=c11 -MMD
 	#CFLAGS += -Os -Wall -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delete-null-pointer-checks -std=c99 -MMD
 	#CFLAGS += -Os -Wall -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delete-null-pointer-checks -std=gnu99 -MMD
 	#CFLAGS += -Os -Wall -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delete-null-pointer-checks -std=gnu11 -MMD
@@ -216,10 +216,11 @@ else
 	CFLAGS += -ffunction-sections -fdata-sections
 endif
 
-# May cause unhelpful build failures
+# Warn about structs wasting space
 #CFLAGS += -Wpadded
 
 # catch any and all warnings
+# better to bust than add new bugs
 #CFLAGS += -Wextra
 
 CFLAGS += -DPRINTF_INCLUDE_CONFIG_H
@@ -345,7 +346,7 @@ endif
 LDFLAGS += --specs=nano.specs
 
 ifeq ($(ENABLE_LTO),0)
-	# Throw away unneeded func/data sections like LTO does
+#	Throw away unneeded func/data sections like LTO does
 	LDFLAGS += -Wl,--gc-sections
 endif
 

--- a/app/main.c
+++ b/app/main.c
@@ -838,6 +838,9 @@ void MAIN_ProcessKeys(key_code_t Key, bool key_pressed, bool key_held)
 	// TODO: ???
 //	if (Key > KEY_PTT)
 //	{
+//		TBR: May be so Key falls into default case in
+//		switch below, making the radio play a beep
+
 //		Key = KEY_SIDE2;      // what's this doing ???
 //	}
 

--- a/functions.h
+++ b/functions.h
@@ -21,7 +21,7 @@
 
 enum function_type_e
 {
-	FUNCTION_FOREGROUND = 0,  // ???
+	FUNCTION_FOREGROUND = 0,  // ??? (TBR: idle, i.e. not in power save)
 	FUNCTION_TRANSMIT,        // transmitting
 	FUNCTION_MONITOR,         // receiving with squelch forced open
 	FUNCTION_INCOMING,        // receiving a signal (squelch is open)

--- a/ui/battery.c
+++ b/ui/battery.c
@@ -44,7 +44,7 @@ void UI_DrawBattery(uint8_t* bitmap, const unsigned int level, const unsigned in
 	}
 	else
 	if (blink == 0)
-		memset(bitmap, 0, sizeof(bitmap));
+		memset(bitmap, 0, sizeof(BITMAP_BATTERY_LEVEL));
 }
 
 void UI_DisplayBattery(const unsigned int level, const unsigned int blink)

--- a/ui/scanner.c
+++ b/ui/scanner.c
@@ -29,7 +29,7 @@
 
 void UI_DisplayScanner(void)
 {
-	char    String[16];
+	char    String[17];
 	bool    text_centered = false;
 
 	memset(g_frame_buffer, 0, sizeof(g_frame_buffer));


### PR DESCRIPTION
We should allow GCC to optimise instructions that are provided as builtins. I have changed code that breaks when `-fno-builtin` is removed from CFLAGS. This saves around 300 bytes with no visible impact on functionality.

No difference in size or function was observed when `-fshort-enums` or `-fno-delete-null-pointer-checks` were removed.

I've omitted changing ENABLE_LTO to 0 as this causes a flash section overflow when the current defaults are used, failing the build.