### PR TITLE
Increase string buffer sizes to avoid overflows

### DIFF
--- a/app/dtmf.c
+++ b/app/dtmf.c
@@ -203,7 +203,7 @@ void DTMF_Append(const char code)
 void DTMF_HandleRequest(void)
 {	// proccess the RX'ed DTMF characters
 
-	char         String[20];
+	char         String[21];
 	unsigned int Offset;
 
 	if (!g_dtmf_rx_pending)
@@ -393,7 +393,7 @@ bool DTMF_Reply(void)
 {
 	const uint16_t Delay   = (g_eeprom.dtmf_preload_time < 150) ? 150 : g_eeprom.dtmf_preload_time;
 	const char    *pString = NULL;
-	char           String[20];
+	char           String[23];
 
 	switch (g_dtmf_reply_state)
 	{

--- a/ui/main.c
+++ b/ui/main.c
@@ -405,7 +405,7 @@ void UI_DisplayMain(void)
 	#endif
 	const unsigned int line0 = 0;  // text screen line
 	const unsigned int line1 = 4;
-	char               String[17];
+	char               String[22];
 	unsigned int       vfo_num;
 
 	center_line = CENTER_LINE_NONE;


### PR DESCRIPTION
The compiler isn't checking boundaries of string arrays. This PR increases the size of buffers that overflow given enough data.

I did try to update printf with a fork, however it was dependent on a Unix function not available to us.