### PR TITLE
Force git's hash to be 10 digits max, as per requested by the python script (git 2.34.1 returns a 12 digits by default for --short).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ ENABLE_KEYLOCK                   := 1
 
 TARGET = firmware
 
-GIT_HASH_TMP := $(shell git rev-parse --short HEAD)
+GIT_HASH_TMP := $(shell git rev-parse --short=10 HEAD)
 ifeq ($(GIT_HASH_TMP), )
 	GIT_HASH := "NOGIT"
 else


### PR DESCRIPTION
BTW, default Makefile enables too much stuff, and .text section overflows the flash region. (I disabled MDC1200 locally).
