### PR TITLE
WIP AGC changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ENABLE_CODE_SEARCH_TIMEOUT       := 0
 # Kill and Revive 0.4 kB
 ENABLE_KILL_REVIVE               := 0
 # AM Fix 0.8 kB
-ENABLE_AM_FIX                    := 1
+ENABLE_AM_FIX                    := 0
 ENABLE_AM_FIX_SHOW_DATA          := 0
 ENABLE_SQUELCH_MORE_SENSITIVE    := 1
 ENABLE_SQ_OPEN_WITH_UP_DN_BUTTS  := 1
@@ -254,7 +254,7 @@ CFLAGS =
 
 ifeq ($(ENABLE_CLANG),0)
 	#CFLAGS += -Os -Wall -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delete-null-pointer-checks -std=c11 -MMD
-	CFLAGS += -Os -Werror -mcpu=cortex-m0 -std=c11 -MMD
+	CFLAGS += -Os -Werror -mcpu=cortex-m0 -fmodulo-sched -freorder-blocks-algorithm=stc -std=c11 -MMD
 else
 	# Oz needed to make it fit on flash
 	CFLAGS += -Oz -Werror -mcpu=cortex-m0 -fno-builtin -fshort-enums -fno-delete-null-pointer-checks -std=c11 -MMD

--- a/app/app.c
+++ b/app/app.c
@@ -551,6 +551,10 @@ bool APP_start_listening(function_type_t Function, const bool reset_am_fix)
 	}
 #else
 	(void)reset_am_fix;
+	if (g_rx_vfo->am_mode)
+		BK4819_EnableAGC();
+	else
+		BK4819_DisableAGC();
 #endif
 
 	// AF gain - original QS values

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -53,8 +53,7 @@ void BK4819_Init(void)
 	BK4819_WriteRegister(BK4819_REG_37, 0x1D0F);
 	BK4819_WriteRegister(BK4819_REG_36, 0x0022);
 
-//	BK4819_SetAGC(0);
-	BK4819_SetAGC(1);     // ???
+	BK4819_DisableAGC();
 
 	BK4819_WriteRegister(BK4819_REG_19, 0x1041);  // 0001 0000 0100 0001 <15> MIC AGC  1 = disable  0 = enable
 
@@ -261,119 +260,84 @@ void BK4819_WriteU16(uint16_t Data)
 	}
 }
 
-void BK4819_SetAGC(uint8_t Value)
+void BK4819_DisableAGC()
 {
-	if (Value == 0)
-	{
-		// REG_10
-		//
-		// 0x0038 Rx AGC Gain Table[0]. (Index Max->Min is 3,2,1,0,-1)
-		//
-		// <15:10> ???
-		//
-		// <9:8>   LNA Gain Short
-		//         3 =   0dB  <<<
-		//         2 = -24dB       // was -11
-		//         1 = -30dB       // was -16
-		//         0 = -33dB       // was -19
-		//
-		// <7:5>   LNA Gain
-		//         7 =   0dB
-		//         6 =  -2dB
-		//         5 =  -4dB
-		//         4 =  -6dB
-		//         3 =  -9dB
-		//         2 = -14dB <<<
-		//         1 = -19dB
-		//         0 = -24dB
-		//
-		// <4:3>   MIXER Gain
-		//         3 =   0dB <<<
-		//         2 =  -3dB
-		//         1 =  -6dB
-		//         0 =  -8dB
-		//
-		// <2:0>   PGA Gain
-		//         7 =   0dB
-		//         6 =  -3dB <<<
-		//         5 =  -6dB
-		//         4 =  -9dB
-		//         3 = -15dB
-		//         2 = -21dB
-		//         1 = -27dB
-		//         0 = -33dB
-		//
-		BK4819_WriteRegister(BK4819_REG_13, (3u << 8) | (2u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
+	// REG_10
+	//
+	// 0x0038 Rx AGC Gain Table[0]. (Index Max->Min is 3,2,1,0,-1)
+	//
+	// <15:10> ???
+	//
+	// <9:8>   LNA Gain Short
+	//         3 =   0dB  <<<
+	//         2 = -24dB       // was -11
+	//         1 = -30dB       // was -16
+	//         0 = -33dB       // was -19
+	//
+	// <7:5>   LNA Gain
+	//         7 =   0dB
+	//         6 =  -2dB
+	//         5 =  -4dB
+	//         4 =  -6dB
+	//         3 =  -9dB
+	//         2 = -14dB <<<
+	//         1 = -19dB
+	//         0 = -24dB
+	//
+	// <4:3>   MIXER Gain
+	//         3 =   0dB <<<
+	//         2 =  -3dB
+	//         1 =  -6dB
+	//         0 =  -8dB
+	//
+	// <2:0>   PGA Gain
+	//         7 =   0dB
+	//         6 =  -3dB <<<
+	//         5 =  -6dB
+	//         4 =  -9dB
+	//         3 = -15dB
+	//         2 = -21dB
+	//         1 = -27dB
+	//         0 = -33dB
+	//
+	BK4819_WriteRegister(BK4819_REG_13, (3u << 8) | (2u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
 
-		BK4819_WriteRegister(BK4819_REG_12, 0x037B);  // 000000 11 011 11 011
-		BK4819_WriteRegister(BK4819_REG_11, 0x027B);  // 000000 10 011 11 011
-		BK4819_WriteRegister(BK4819_REG_10, 0x007A);  // 000000 00 011 11 010
-		BK4819_WriteRegister(BK4819_REG_14, 0x0019);  // 000000 00 000 11 001
+	BK4819_WriteRegister(BK4819_REG_12, 0x037B);  // 000000 11 011 11 011
+	BK4819_WriteRegister(BK4819_REG_11, 0x027B);  // 000000 10 011 11 011
+	BK4819_WriteRegister(BK4819_REG_10, 0x007A);  // 000000 00 011 11 010
+	BK4819_WriteRegister(BK4819_REG_14, 0x0019);  // 000000 00 000 11 001
 
-		BK4819_WriteRegister(BK4819_REG_49, 0x2A38);
-		BK4819_WriteRegister(BK4819_REG_7B, 0x8420);
-	}
-	else
-	if (Value == 1)
-	{	// what does this do ???
+	// undocumented ?
+	BK4819_WriteRegister(BK4819_REG_49, 0x2A38);
+	BK4819_WriteRegister(BK4819_REG_7B, 0x8420);
 
-		unsigned int i;
+	// undoes BK4819_EnableAGC reg write
+	BK4819_WriteRegister(BK4819_REG_7E, (0u << 15));
+}
 
-		// REG_10
-		//
-		// 0x0038 Rx AGC Gain Table[0]. (Index Max->Min is 3,2,1,0,-1)
-		//
-		// (15:10> ???
-		//
-		// <9:8>   LNA Gain Short
-		//         3 =   0dB   << original
-		//         2 = -24dB       // was -11
-		//         1 = -30dB       // was -16
-		//         0 = -33dB       // was -19
-		//
-		// <7:5>   LNA Gain
-		//         7 =   0dB
-		//         6 =  -2dB
-		//         5 =  -4dB
-		//         4 =  -6dB
-		//         3 =  -9dB
-		//         2 = -14dB   << original
-		//         1 = -19dB
-		//         0 = -24dB
-		//
-		// <4:3>   MIXER Gain
-		//         3 =   0dB   << original
-		//         2 =  -3dB
-		//         1 =  -6dB
-		//         0 =  -8dB
-		//
-		// <2:0>   PGA Gain
-		//         7 =   0dB
-		//         6 =  -3dB   << original
-		//         5 =  -6dB
-		//         4 =  -9dB
-		//         3 = -15dB
-		//         2 = -21dB
-		//         1 = -27dB
-		//         0 = -33dB
-		//
-		BK4819_WriteRegister(BK4819_REG_13, (3u << 8) | (2u << 5) | (3u << 3) | (6u << 0));
+void BK4819_EnableAGC()
+{	// what does this do ???
+	//
+	// REG_7E
+	//
+	// <15> 0 AGC Fix Mode.
+	// 1=Fix; 0=Auto.
+	//
+	// <14:12> 0b011 AGC Fix Index.
+	// 011=Max, then 010,001,000,111,110,101,100(min).
+	//
+	// <5:3> 0b101 DC Filter Band Width for Tx (MIC In).
+	// 000=Bypass DC filter;
+	//
+	// <2:0> 0b110 DC Filter Band Width for Rx (IF In).
+	// 000=Bypass DC filter;
 
-		BK4819_WriteRegister(BK4819_REG_12, 0x037C);  // 000000 11 011 11 100
-		BK4819_WriteRegister(BK4819_REG_11, 0x027B);  // 000000 10 011 11 011
-		BK4819_WriteRegister(BK4819_REG_10, 0x007A);  // 000000 00 011 11 010
-		BK4819_WriteRegister(BK4819_REG_14, 0x0018);  // 000000 00 000 11 000
+	BK4819_WriteRegister(BK4819_REG_7E, (1u << 15));
+	//BK4819_WriteRegister(BK4819_REG_7E, (3u << 12) | (5u << 3) | (6u << 0));
 
-		BK4819_WriteRegister(BK4819_REG_49, 0x2A38);
-		BK4819_WriteRegister(BK4819_REG_7B, 0x318C);
-
-		BK4819_WriteRegister(BK4819_REG_7C, 0x595E);
-		BK4819_WriteRegister(BK4819_REG_20, 0x8DEF);
-
-		for (i = 0; i < 8; i++)
-			// Bug? The bit 0x2000 below overwrites the (i << 13)
-			BK4819_WriteRegister(BK4819_REG_06, ((i << 13) | 0x2500u) + 0x036u);
-	}
+	//for (unsigned int i = 0; i < 8; i++)
+	//	// Bug? The bit 0x2000 below overwrites the (i << 13)
+	//	BK4819_WriteRegister(BK4819_REG_06, ((i << 13) | 0x2500u) + 0x036u);
 }
 
 void BK4819_set_GPIO_pin(bk4819_gpio_pin_t Pin, bool bSet)

--- a/driver/bk4819.h
+++ b/driver/bk4819.h
@@ -67,7 +67,8 @@ void     BK4819_WriteRegister(bk4819_register_t Register, uint16_t Data);
 void     BK4819_WriteU8(uint8_t Data);
 void     BK4819_WriteU16(uint16_t Data);
 
-void     BK4819_SetAGC(uint8_t Value);
+void     BK4819_DisableAGC();
+void     BK4819_EnableAGC();
 
 void     BK4819_set_GPIO_pin(bk4819_gpio_pin_t Pin, bool bSet);
 


### PR DESCRIPTION
This PR relates to #218.

The aim is to investigate the possibility of getting AGC working as documentation suggests this is disabled by default (pg. 11). Currently the SetAGC code matches that of the RT-890, where it's disabled but never enabled. I hope this can offer an alternative fix for distorted AM signals when completed.