### PR TITLE
Swap AGC values to match reference OEFW, attempt to attenuate overloading signals

### DIFF
--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -313,16 +313,16 @@ void BK4819_DisableAGC(void)
 	//         0 = -33dB
 	//
 	BK4819_WriteRegister(0x13, (3u << 8) | (5u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
-    BK4819_WriteRegister(0x12, 0x037C);
-    BK4819_WriteRegister(0x11, 0x027B);
-    BK4819_WriteRegister(0x10, 0x007A);
-    BK4819_WriteRegister(0x14, 0x0018);
+	BK4819_WriteRegister(0x12, 0x037C);  // 000000 11 011 11 100
+	BK4819_WriteRegister(0x11, 0x027B);  // 000000 10 011 11 011
+	BK4819_WriteRegister(0x10, 0x007A);  // 000000 00 011 11 010
+	BK4819_WriteRegister(0x14, 0x0018);  // 000000 00 000 11 000
 
 	// undocumented ?
-    BK4819_WriteRegister(0x49, 0x2A38);
-    BK4819_WriteRegister(0x7B, 0x318C);
-    BK4819_WriteRegister(0x7C, 0x595E);
-    BK4819_WriteRegister(0x20, 0x8DEF);
+	BK4819_WriteRegister(0x49, 0x2A38);
+	BK4819_WriteRegister(0x7B, 0x318C);
+	BK4819_WriteRegister(0x7C, 0x595E);
+	BK4819_WriteRegister(0x20, 0x8DEF);
 
 	// fagci had the answer to why we weren't as sensitive!
 	for (unsigned int i = 0; i < 8; i++)

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -346,9 +346,6 @@ void BK4819_DisableAGC(void)
 
 void BK4819_EnableAGC(void)
 {
-	// TODO: See if this attenuates overloading
-	// signals as well as boosting weak ones
-	//
 	// REG_7E
 	//
 	// <15> 0 AGC Fix Mode.
@@ -362,25 +359,29 @@ void BK4819_EnableAGC(void)
 	//
 	// <2:0> 0b110 DC Filter Band Width for Rx (IF In).
 	// 000=Bypass DC filter;
-
+	//
 	// TBR: I believe the above filter values do the following:
 	// High-Pass (300Hz?), Low-Pass (3kHz?), De-Emphasis (attenuates higher freq range)
 	// This assumes the same filter layout as REG_2B
-
 	BK4819_WriteRegister(0x7E,
 		(0u << 15) |      // 0  AGC fix mode
 		(3u << 12) |      // 3  AGC fix index
 		(5u <<  3) |      // 5  DC Filter band width for Tx (MIC In)
 		(6u <<  0));      // 6  DC Filter band width for Rx (I.F In)
 
+	// TBR: fagci has this listed as two values, agc_rssi and lna_peak_rssi
+	// This is why AGC appeared to do nothing as-is for Rx
+	//
 	// REG_62
 	//
-	// TBR: fagci has this listed as two values, agc_rssi and lna_peak_rssi
-	// Could this be why AGC appeared to do nothing? Default: 0xFF (255)
-	BK4819_WriteRegister(0x62, 0x8F);
+	// <15:8> 0xFF AGC RSSI
+	//
+	// <7:0> 0xFF LNA Peak RSSI
+	//
+	// TBR: Using S9+30 (173) and S9 (143) as suggested values
+	BK4819_WriteRegister(0x62, (173u << 8) | (143u << 0));
 
-	// In theory, AGC should auto-adjust LNA values
-	// In practice, it seems to work against us
+	// AGC auto-adjusts the following LNA values, no need to set them ourselves
 	//BK4819_WriteRegister(0x13, (3u << 8) | (5u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
 	//BK4819_WriteRegister(0x12, 0x037B);  // 000000 11 011 11 011
 	//BK4819_WriteRegister(0x11, 0x027B);  // 000000 10 011 11 011

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -313,14 +313,20 @@ void BK4819_DisableAGC(void)
 	//         0 = -33dB
 	//
 	BK4819_WriteRegister(0x13, (3u << 8) | (5u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
-	BK4819_WriteRegister(0x12, 0x037B);  // 000000 11 011 11 011
-	BK4819_WriteRegister(0x11, 0x027B);  // 000000 10 011 11 011
-	BK4819_WriteRegister(0x10, 0x007A);  // 000000 00 011 11 010
-	BK4819_WriteRegister(0x14, 0x0019);  // 000000 00 000 11 001
+    BK4819_WriteRegister(0x12, 0x037C);
+    BK4819_WriteRegister(0x11, 0x027B);
+    BK4819_WriteRegister(0x10, 0x007A);
+    BK4819_WriteRegister(0x14, 0x0018);
 
 	// undocumented ?
-	BK4819_WriteRegister(0x49, 0x2A38);
-	BK4819_WriteRegister(0x7B, 0x8420);
+    BK4819_WriteRegister(0x49, 0x2A38);
+    BK4819_WriteRegister(0x7B, 0x318C);
+    BK4819_WriteRegister(0x7C, 0x595E);
+    BK4819_WriteRegister(0x20, 0x8DEF);
+
+	// fagci had the answer to why we weren't as sensitive!
+	for (unsigned int i = 0; i < 8; i++)
+		BK4819_WriteRegister(0x06, ((i & 7u) << 13) | (0x4A << 7) | (0x36 << 0));
 }
 
 void BK4819_EnableAGC(void)
@@ -342,8 +348,9 @@ void BK4819_EnableAGC(void)
 	// <2:0> 0b110 DC Filter Band Width for Rx (IF In).
 	// 000=Bypass DC filter;
 
-	// default fix index too strong, set to min (011->100)
-	//BK4819_WriteRegister(0x7E, (1u << 15) | (4u << 12) | (5u << 3) | (6u << 0));
+	// TBR: I believe the above filter values do the following:
+	// High-Pass (300Hz?), Low-Pass (3kHz?), De-Emphasis (attenuates higher freq range)
+	// This assumes the same filter layout as REG_2B
 
 	BK4819_WriteRegister(0x7E,
 		(0u << 15) |      // 0  AGC fix mode
@@ -351,21 +358,17 @@ void BK4819_EnableAGC(void)
 		(5u <<  3) |      // 5  DC Filter band width for Tx (MIC In)
 		(6u <<  0));      // 6  DC Filter band width for Rx (I.F In)
 
+	// In theory, AGC should auto-adjust LNA values
+	// In practice, it seems to work against us
 	BK4819_WriteRegister(0x13, (3u << 8) | (5u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
-    BK4819_WriteRegister(0x12, 0x037C);
-    BK4819_WriteRegister(0x11, 0x027B);
-    BK4819_WriteRegister(0x10, 0x007A);
-    BK4819_WriteRegister(0x14, 0x0018);
+	BK4819_WriteRegister(0x12, 0x037B);  // 000000 11 011 11 011
+	BK4819_WriteRegister(0x11, 0x027B);  // 000000 10 011 11 011
+	BK4819_WriteRegister(0x10, 0x007A);  // 000000 00 011 11 010
+	BK4819_WriteRegister(0x14, 0x0019);  // 000000 00 000 11 001
 
 	// undocumented ?
-    BK4819_WriteRegister(0x49, 0x2A38);
-    BK4819_WriteRegister(0x7B, 0x318C);
-    BK4819_WriteRegister(0x7C, 0x595E);
-    BK4819_WriteRegister(0x20, 0x8DEF);
-
-	// fagci had the answer to why we weren't as sensitive!
-	for (unsigned int i = 0; i < 8; i++)
-		BK4819_WriteRegister(0x06, ((i & 7u) << 13) | (0x4A << 7) | (0x36 << 0));
+	BK4819_WriteRegister(0x49, 0x2A38);
+	BK4819_WriteRegister(0x7B, 0x8420);
 }
 
 void BK4819_set_GPIO_pin(bk4819_gpio_pin_t Pin, bool bSet)

--- a/driver/bk4819.c
+++ b/driver/bk4819.c
@@ -322,6 +322,21 @@ void BK4819_DisableAGC(void)
 	BK4819_WriteRegister(0x49, 0x2A38);
 	BK4819_WriteRegister(0x7B, 0x318C);
 	BK4819_WriteRegister(0x7C, 0x595E);
+
+	// REG_20 (undocumented)
+	//
+	// 0x8DEF Soft Mute
+	//
+	// <12> 1 Soft Mute Enable
+	//
+	// <11:10> 00 Unknown ?
+	//
+	// <9:8> 0b11 Soft Mute Rate
+	//
+	// <7:6> 0b11 Soft Mute Attenuation
+	//
+	// <5:0> 0b111111 Signal-to-Noise Ratio Threshold
+	//
 	BK4819_WriteRegister(0x20, 0x8DEF);
 
 	// fagci had the answer to why we weren't as sensitive!
@@ -358,13 +373,19 @@ void BK4819_EnableAGC(void)
 		(5u <<  3) |      // 5  DC Filter band width for Tx (MIC In)
 		(6u <<  0));      // 6  DC Filter band width for Rx (I.F In)
 
+	// REG_62
+	//
+	// TBR: fagci has this listed as two values, agc_rssi and lna_peak_rssi
+	// Could this be why AGC appeared to do nothing? Default: 0xFF (255)
+	BK4819_WriteRegister(0x62, 0x8F);
+
 	// In theory, AGC should auto-adjust LNA values
 	// In practice, it seems to work against us
-	BK4819_WriteRegister(0x13, (3u << 8) | (5u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
-	BK4819_WriteRegister(0x12, 0x037B);  // 000000 11 011 11 011
-	BK4819_WriteRegister(0x11, 0x027B);  // 000000 10 011 11 011
-	BK4819_WriteRegister(0x10, 0x007A);  // 000000 00 011 11 010
-	BK4819_WriteRegister(0x14, 0x0019);  // 000000 00 000 11 001
+	//BK4819_WriteRegister(0x13, (3u << 8) | (5u << 5) | (3u << 3) | (6u << 0));  // 000000 11 101 11 110
+	//BK4819_WriteRegister(0x12, 0x037B);  // 000000 11 011 11 011
+	//BK4819_WriteRegister(0x11, 0x027B);  // 000000 10 011 11 011
+	//BK4819_WriteRegister(0x10, 0x007A);  // 000000 00 011 11 010
+	//BK4819_WriteRegister(0x14, 0x0019);  // 000000 00 000 11 001
 
 	// undocumented ?
 	BK4819_WriteRegister(0x49, 0x2A38);


### PR DESCRIPTION
I learned yesterday that AGC=1 means fixed control while AGC=0 means auto control. This means #223 that sought to align the other gain registers (sans REG_13 as that's airband) ended up doing so inversely. This PR fixes that to match what was intended.

FWIW, the difference is two values bumping up/down PGA by a single index. We know they do something because REG_10, 11, 12 and 14 are related to 13. As outlined in #235, these would need calibration through signal generators to get an average value that works across most radios. There are also writes to undocumented registers.

For now, this will do until we have something better.