### PR TITLE
Hide HML only if TX disabled for the corresponding VFO

### DIFF
--- a/ui/main.c
+++ b/ui/main.c
@@ -853,10 +853,10 @@ void UI_DisplayMain(void)
 		#ifdef ENABLE_TX_WHEN_AM
 			if (state == VFO_STATE_NORMAL || state == VFO_STATE_ALARM)
 		#else
-			if ((state == VFO_STATE_NORMAL || state == VFO_STATE_ALARM) && !g_current_vfo->am_mode) // not allowed to TX if in AM mode
+			if ((state == VFO_STATE_NORMAL || state == VFO_STATE_ALARM) && !g_eeprom.vfo_info[vfo_num].am_mode) // not allowed to TX if in AM mode
 		#endif
 		{
-			if (FREQUENCY_tx_freq_check(g_current_vfo->p_tx->frequency) == 0)
+			if (FREQUENCY_tx_freq_check(g_eeprom.vfo_info[vfo_num].p_tx->frequency) == 0)
 			{	// show the TX power
 				const char pwr_list[] = "LMH";
 				const unsigned int i = g_eeprom.vfo_info[vfo_num].output_power;


### PR DESCRIPTION
Hi,
Currently, the HML indicator display is calculated for the 2 VFOs from the selected VFO only.
For example, if you have a channel that can TX on VFO 1 and one that cannot on VFO 2, switching active VFO will hide and display the 2 HML indicators.
With this small modification, each VFO will display HML if it can TX itself, regardless of which one is selected.
Many thanks for your hard work !