### PR TITLE
Do call CRC_Init if not enabled

### DIFF
--- a/main.c
+++ b/main.c
@@ -169,7 +169,9 @@ void Main(void)
 
 	BOARD_PORTCON_Init();
 	BOARD_GPIO_Init();
+#if defined(ENABLE_AIRCOPY) || defined(ENABLE_UART) || defined(ENABLE_MDC1200)
 	CRC_Init();
+#endif
 	#ifdef ENABLE_UART
 		UART_Init();
 	#endif


### PR DESCRIPTION
If disabling all users of CRC the CRC_Init code is not available but still called. Leading to a linker error. 
Fix it by checking the same options as those used for enabling the CRC.c file.